### PR TITLE
Fix release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pypostalcode
-version = 0.4.0
+version = 0.4.1
 author = Scott Rodkey
 author_email = rodkeyscott@gmail.com
 description = Radius searches on Canadian postal codes, location data
@@ -17,7 +17,6 @@ zip_safe = False
 py_modules =
     pypostalcode
 install_requires =
-include_package_data = True
 
 [options.extras_require]
 dev = pytz; timezonefinder


### PR DESCRIPTION
I think the issue is that `include_package_data = True` causes it to read MANIFEST.in to see which files to include, whereas `package_data` specifies the list of files to include in setup.cfg. These are different options that don't need to be used together.